### PR TITLE
cordova build process  / splash image expansion

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,57 +6,6 @@ var _      = require('underscore');
 var Q      = require('q');
 
 /**
- * Check which platforms are added to the project and return their icon names and sized
- *
- * @param  {String} projectName
- * @return {Promise} resolves with an array of platforms
- */
-var getPlatforms = function (projectName) {
-    var deferred = Q.defer();
-    var platforms = [];
-    platforms.push({
-        name : 'ios',
-        // TODO: use async fs.exists
-        isAdded : fs.existsSync('platforms/ios'),
-        iconsPath : 'platforms/ios/' + projectName + '/Resources/icons/',
-        icons : [
-            { name : 'icon-40.png',       size : 40  },
-            { name : 'icon-40@2x.png',    size : 80  },
-            { name : 'icon-50.png',       size : 50  },
-            { name : 'icon-50@2x.png',    size : 100 },
-            { name : 'icon-60.png',       size : 60  },
-            { name : 'icon-60@2x.png',    size : 120 },
-            { name : 'icon-60@3x.png',    size : 180 },
-            { name : 'icon-72.png',       size : 72  },
-            { name : 'icon-72@2x.png',    size : 144 },
-            { name : 'icon-76.png',       size : 76  },
-            { name : 'icon-76@2x.png',    size : 152 },
-            { name : 'icon-small.png',    size : 29  },
-            { name : 'icon-small@2x.png', size : 58  },
-            { name : 'icon.png',          size : 57  },
-            { name : 'icon@2x.png',       size : 114 },
-        ]
-    });
-    platforms.push({
-        name : 'android',
-        iconsPath : 'platforms/android/res/',
-        isAdded : fs.existsSync('platforms/android'),
-        icons : [
-            { name : 'drawable/icon.png',       size : 96 },
-            { name : 'drawable-hdpi/icon.png',  size : 72 },
-            { name : 'drawable-ldpi/icon.png',  size : 36 },
-            { name : 'drawable-mdpi/icon.png',  size : 48 },
-            { name : 'drawable-xhdpi/icon.png', size : 96 },
-            { name : 'drawable-xxhdpi/icon.png', size : 144 },
-        ]
-    });
-    // TODO: add all platforms
-    deferred.resolve(platforms);
-    return deferred.promise;
-};
-
-
-/**
  * @var {Object} settings - names of the confix file and of the icon image
  * TODO: add option to get these values as CLI params
  */
@@ -126,22 +75,39 @@ var generateIcon = function (platform, image) {
     
     if(platform.type == 'Icons'){
         imageProp.srcPath = settings.ICON_FILE;
+        resizeImage();
     } else {
         if(image.width > image.height){
             imageProp.srcPath = settings.SPLASH_FILE_LANDSCAPE;
+            cropImage();
         } else {
             imageProp.srcPath = settings.SPLASH_FILE_PORTRAIT;
+            cropImage();
         }
     }
 
-    ig.resize(imageProp, function(err, stdout, stderr){
-        if (err) {
-            deferred.reject(err);
-        } else {
-            deferred.resolve();
-            display.success(image.name + ' created');
-        }
-    });
+    function resizeImage(){
+        ig.resize(imageProp, function(err, stdout, stderr){
+            if (err) {
+                deferred.reject(err);
+            } else {
+                deferred.resolve();
+                display.success(image.name + ' created');
+            }
+        });
+    }
+
+    function cropImage(){
+        ig.crop(imageProp, function(err, stdout, stderr){
+            if (err) {
+                deferred.reject(err);
+            } else {
+                deferred.resolve();
+                display.success(image.name + ' created');
+            }
+        });
+    }
+
 
     return deferred.promise;
 };
@@ -377,7 +343,6 @@ atLeastOnePlatformFound()
     .then(validImagesExist)
     .then(configFileExists)
     .then(getProjectName)
-    // .then(getPlatforms)
     .then(getPlatformsFromConfig)
     .then(generateIcons)
     .catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ var getPlatforms = function (projectName) {
  */
 var settings = {};
 settings.CONFIG_FILE = 'config.xml';
-settings.ICON_FILE   = 'icon.png';
+settings.ICON_FILE   = 'res/icon.png';
+settings.SPLASH_FILE_PORTRAIT = 'res/splash_p.png';
+settings.SPLASH_FILE_LANDSCAPE = 'res/splash_l.png';
 
 /**
  * @var {Object} console utils
@@ -112,23 +114,35 @@ var getProjectName = function () {
  * @param  {Object} icon
  * @return {Promise}
  */
-var generateIcon = function (platform, icon) {
+var generateIcon = function (platform, image) {
     var deferred = Q.defer();
-    ig.resize({
-        srcPath: settings.ICON_FILE,
-        dstPath: platform.iconsPath + icon.name,
+    var imageProp = {
+        dstPath: platform.iconsPath + image.name,
         quality: 1,
         format: 'png',
-        width: icon.size,
-        height: icon.size,
-    } , function(err, stdout, stderr){
+        width: image.width,
+        height: image.height,
+    };
+    
+    if(platform.type == 'Icons'){
+        imageProp.srcPath = settings.ICON_FILE;
+    } else {
+        if(image.width > image.height){
+            imageProp.srcPath = settings.SPLASH_FILE_LANDSCAPE;
+        } else {
+            imageProp.srcPath = settings.SPLASH_FILE_PORTRAIT;
+        }
+    }
+
+    ig.resize(imageProp, function(err, stdout, stderr){
         if (err) {
             deferred.reject(err);
         } else {
             deferred.resolve();
-            display.success(icon.name + ' created');
+            display.success(image.name + ' created');
         }
     });
+
     return deferred.promise;
 };
 
@@ -140,12 +154,19 @@ var generateIcon = function (platform, icon) {
  */
 var generateIconsForPlatform = function (platform) {
     var deferred = Q.defer();
-    display.header('Generating Icons for ' + platform.name);
+    display.header('Generating ' + platform.type + ' for ' + platform.name);
     var all = [];
-    var icons = platform.icons;
-    icons.forEach(function (icon) {
-        all.push(generateIcon(platform, icon));
-    });
+    
+    if (platform.icons) {
+        platform.icons.forEach(function (icon) {
+            all.push(generateIcon(platform, icon));
+        });
+    } else {
+        platform.splashes.forEach(function (splash) {
+            all.push(generateIcon(platform, splash));
+        });
+    }
+
     Q.all(all).then(function () {
         deferred.resolve();
     }).catch(function (err) {
@@ -183,7 +204,7 @@ var generateIcons = function (platforms) {
  */
 var atLeastOnePlatformFound = function () {
     var deferred = Q.defer();
-    getPlatforms().then(function (platforms) {
+    getPlatformsFromConfig().then(function (platforms) {
         var activePlatforms = _(platforms).where({ isAdded : true });
         if (activePlatforms.length > 0) {
             display.success('platforms found: ' + _(activePlatforms).pluck('name').join(', '));
@@ -197,18 +218,38 @@ var atLeastOnePlatformFound = function () {
 };
 
 /**
- * Checks if a valid icon file exists
+ * Checks if a valid images files exist
  *
  * @return {Promise} resolves if exists, rejects otherwise
  */
-var validIconExists = function () {
+var validImagesExist = function () {
     var deferred = Q.defer();
-    fs.exists(settings.ICON_FILE, function (exists) {
+    var all = []
+    
+    all.push(checkImage(settings.ICON_FILE));
+    all.push(checkImage(settings.SPLASH_FILE_PORTRAIT));
+    all.push(checkImage(settings.SPLASH_FILE_LANDSCAPE));
+
+    Q.all(all).then(function () {
+        deferred.resolve();
+    });
+
+    return deferred.promise;
+};
+
+/**
+ * Checks if a valid image file exists
+ *
+ * @return {Promise} resolves if exists, rejects otherwise
+ */
+var checkImage = function (file) {
+    var deferred = Q.defer();
+    fs.exists(file, function (exists) {
         if (exists) {
-            display.success(settings.ICON_FILE + ' exists');
+            display.success(file + ' exists');
             deferred.resolve();
         } else {
-            display.error(settings.ICON_FILE + ' does not exist in the root folder');
+            display.error(file + ' does not exist in the root folder');
             deferred.reject();
         }
     });
@@ -234,13 +275,110 @@ var configFileExists = function () {
     return deferred.promise;
 };
 
+/**
+ * Check which platforms are added to the project (via confix.xml) and return their icon names and size
+ *
+ * @param  {String} projectName
+ * @return {Promise} resolves with an array of platforms
+ */
+var getPlatformsFromConfig = function (projectName) {
+    var deferred = Q.defer();
+    var parser = new xml2js.Parser();
+    var platforms = [];
+    var folderCount = 0;
+    var all = [];
+
+    fs.readFile(settings.CONFIG_FILE, 'utf8', function(err, data){
+        parser.parseString(data, function (err, result) {
+            result.widget.platform.forEach(function(node){
+                getIcons(node, platforms, function(platforms_result){
+                    getSplash(node, platforms, function(platforms_result){
+                        folderCount++;
+
+                        if(folderCount == result.widget.platform.length){
+                            deferred.resolve(platforms_result);
+                        }
+                    });
+                });
+            });            
+        });
+    });
+
+    return deferred.promise;
+};
+
+/**
+ * extract the icon information from the node structure
+ *
+ * @param  {Object} node
+ * @param  {Array} platforms
+ * @param  {String} cb
+ * @return {Function} function with platforms array
+ */
+var getIcons = function (node, platforms, cb) {
+    var platform = {};
+
+    fs.mkdir('res/' + node.$.name, function(err){
+
+        platform.name = node.$.name;
+        platform.iconsPath = '';
+        platform.isAdded = fs.existsSync('platforms/' + node.$.name),
+        platform.icons = [];
+        platform.type = 'Icons';
+
+        if(node.icon){
+            node.icon.forEach(function(icon){
+                platform.icons.push({ name: icon.$.src, width: icon.$.width, height: icon.$.height });
+            });
+        }
+
+        platforms.push(platform);
+
+        return cb(platforms);
+    });
+};
+
+/**
+ * extract the splash information from the node structure
+ *
+ * @param  {Object} node
+ * @param  {Array} platforms
+ * @param  {String} cb
+ * @return {Function} function with platforms array
+ */
+var getSplash = function (node, platforms, cb) {
+    var platform = {};
+
+    fs.mkdir('res/screen', function(err){
+        fs.mkdir('res/screen/' + node.$.name, function(err){
+
+            platform.name = node.$.name;
+            platform.iconsPath = '';
+            platform.isAdded = fs.existsSync('platforms/' + node.$.name),
+            platform.splashes = [];
+            platform.type = 'Splashes';
+
+            if(node.splash){
+                node.splash.forEach(function(splash){
+                    platform.splashes.push({ name: splash.$.src, width: splash.$.width, height: splash.$.height });
+                });
+            }
+
+            platforms.push(platform);
+
+            return cb(platforms);
+        });
+    });
+};
+
 display.header('Checking Project & Icon');
 
 atLeastOnePlatformFound()
-    .then(validIconExists)
+    .then(validImagesExist)
     .then(configFileExists)
     .then(getProjectName)
-    .then(getPlatforms)
+    // .then(getPlatforms)
+    .then(getPlatformsFromConfig)
     .then(generateIcons)
     .catch(function (err) {
         if (err) {


### PR DESCRIPTION
Here are couple of changes that include: 

* Integration for Cordova build process
* Ability to control assets from config.xml (that is used with the build process)
* Unlimited platform support via config.xml
* Portrait/Landscape Splash image support

Since the change aims to work with the Cordova build process we change the build order to generate images before Cordova builds the rest of the project. 

change
```
hooks/after_prepare/cordova-icon.sh
```
to
```
hooks/before_build/cordova-icon.sh
```

Next, we want to declare the various icons and splash images that Cordova will pick up in the `config.xml ` file:

example (making sure that each icon/splash image contains `width` and `height`):
```
<platform name="android">
        <icon src="res/android/ldpi.png" density="ldpi" width="36" height="36" />
        <icon src="res/android/mdpi.png" density="mdpi" width="48" height="48" />
        <icon src="res/android/hdpi.png" density="hdpi" width="72" height="72" />
        <icon src="res/android/xhdpi.png" density="xhdpi" width="96" height="96" />
</platform>
```

More config information can be found here, [Apache Cordova Documentation](https://cordova.apache.org/docs/en/4.0.0/config_ref_images.md.html)

Finally, after global installation of this project you will be able to run commands like, `cordova build android`, `cordova run ios` , etc. to generate icons and build the entire project(s).

