### PR TITLE
Check if ImageMagick is installed + Make requirements more visible in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Automatic icon resizing for Cordova. Create an icon in the root folder of your C
 
      $ sudo npm install cordova-icon -g
 
+### Requirements
+
+- ImageMagick installed (*Mac*: `brew install imagemagick`, *Debian/Ubuntu*: `sudo apt-get install imagemagick`), *Windows*: [See here](http://www.imagemagick.org/script/binary-releases.php#windows))
+- At least one platform was added to your project ([cordova platforms docs](http://cordova.apache.org/docs/en/edge/guide_platforms_index.md.html#Platform%20Guides))
+- Cordova's config.xml file must exist in the root folder ([cordova config.xml docs](http://cordova.apache.org/docs/en/edge/config_ref_index.md.html#The%20config.xml%20File))
+
 ### Usage
 
-Create an ```icon.png``` file in the root folder of your cordova project and run:
+Create an `icon.png` file in the root folder of your cordova project and run:
 
      $ cordova-icon
 
@@ -34,24 +40,11 @@ Then give the script +x permission:
 
     $ chmod +x hooks/after_prepare/cordova-icon.sh
 
-That's it. Now every time you ```cordova build```, the icons will be auto generated.
-
-### Requirements
-
-- ImageMagick
-
-Install on a Mac:
-
-     $ brew install imagemagick
-
-On windows see http://www.imagemagick.org/script/binary-releases.php#windows
-
-- At least one platform was added to your project ([cordova platforms docs](http://cordova.apache.org/docs/en/3.4.0/guide_platforms_index.md.html#Platform%20Guides))
-- Cordova's config.xml file must exist in the root folder ([cordova config.xml docs](http://cordova.apache.org/docs/en/3.4.0/config_ref_index.md.html#The%20config.xml%20File))
+That's it. Now every time you `cordova build`, the icons will be auto generated.
 
 ### Splash screens
 
-check out [cordova-splash](https://github.com/AlexDisler/cordova-splash)
+Check out [cordova-splash](https://github.com/AlexDisler/cordova-splash).
 
 ### License
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var ig     = require('imagemagick');
 var colors = require('colors');
 var _      = require('underscore');
 var Q      = require('q');
+var exec   = require('child_process').exec;
 
 /**
  * Check which platforms are added to the project and return their icon names and sized
@@ -156,7 +157,7 @@ var generateIconsForPlatform = function (platform) {
 
 /**
  * Goes over all the platforms and triggers icon generation
- * 
+ *
  * @param  {Array} platforms
  * @return {Promise}
  */
@@ -172,6 +173,25 @@ var generateIcons = function (platforms) {
     });
     Q.all(all).then(function () {
         deferred.resolve();
+    });
+    return deferred.promise;
+};
+
+/**
+ * Checks if ImageMagick is installed
+ *
+ * @return {Promise} resolves if ImageMagick is installed, rejects otherwise
+ */
+var imageMagickInstalled = function () {
+    var deferred = Q.defer();
+    exec('convert -version', function (error) {
+        if (!error) {
+            display.success('ImageMagick found');
+            deferred.resolve();
+        } else {
+            display.error('ImageMagick is not installed/available. Please see README.md for instructions.');
+            deferred.reject();
+        }
     });
     return deferred.promise;
 };
@@ -236,7 +256,8 @@ var configFileExists = function () {
 
 display.header('Checking Project & Icon');
 
-atLeastOnePlatformFound()
+imageMagickInstalled()
+    .then(atLeastOnePlatformFound)
     .then(validIconExists)
     .then(configFileExists)
     .then(getProjectName)


### PR DESCRIPTION
This should help some people, since most of the issues are coming from ImageMagick not being installed.

The check is [from here](http://stackoverflow.com/questions/16976655/node-js-graphicsmagic-check-installation-functionality/16977899#16977899).
