### PR TITLE
Fix "unable to open image" errors when creating Android icons

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,14 +41,19 @@ var getPlatforms = function (projectName) {
         name : 'android',
         iconsPath : 'platforms/android/res/',
         isAdded : fs.existsSync('platforms/android'),
-        icons : [
-            { name : 'drawable/icon.png',       size : 96 },
-            { name : 'drawable-hdpi/icon.png',  size : 72 },
-            { name : 'drawable-ldpi/icon.png',  size : 36 },
-            { name : 'drawable-mdpi/icon.png',  size : 48 },
-            { name : 'drawable-xhdpi/icon.png', size : 96 },
-            { name : 'drawable-xxhdpi/icon.png', size : 144 },
-        ]
+        get icons () {
+            return [
+                    { name : 'drawable/icon.png',           size : 96 },
+                    { name : 'drawable-hdpi/icon.png',      size : 72  },
+                    { name : 'drawable-ldpi/icon.png',      size : 36  },
+                    { name : 'drawable-mdpi/icon.png',      size : 48  },
+                    { name : 'drawable-xhdpi/icon.png',     size : 96  },
+                    { name : 'drawable-xxhdpi/icon.png',    size : 144 },
+                    { name : 'drawable-xxxhdpi/icon.png',   size : 192 }
+                ].filter(function (config) {
+                    return fs.existsSync(this.iconsPath + config.name.split('/')[0]);
+                }, this);
+        }
     });
     // TODO: add all platforms
     deferred.resolve(platforms);


### PR DESCRIPTION
This PR provides a more robust way of generating Android icons by checking if the specified folders do actually exist. It is based on #42, but more generic because it handles all the cases where the `drawable-...` folder does not exist (e.g. `drawable-xxxhdpi`).

Fixes #31 
Substitutes #42 #32 #24