### PR TITLE
Ensure specified image proportions

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ var generateIcon = function (platform, icon) {
         quality: 1,
         format: 'png',
         width: icon.size,
-        height: icon.size,
+        height: icon.size+'!',
     } , function(err, stdout, stderr){
         if (err) {
             deferred.reject(err);


### PR DESCRIPTION
This ensures that the output images have the correct width and height, even if `icon.png` has an aspect ratio different than 1 (square). Why? I got cordova errors about the images sizes before noticing my icon wasn't squared.

The exclamation mark added tells imagemagick to stick to the width and height given, no matter what, as found [here](http://stackoverflow.com/a/2130327/1456173). I checked compatibility with yourdeveloper/node-imagemagick and tested locally.

Thanks.