### PR TITLE
Don't swallow errors if fail to generate icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,6 +221,7 @@ var generateIcon = function (platform, icon) {
   } , function(err, stdout, stderr){
     if (err) {
       deferred.reject(err);
+      display.error('Failed to create ' + icon.name);
     } else {
       deferred.resolve();
       display.success(icon.name + ' created');
@@ -280,6 +281,10 @@ var generateIcons = function (platforms) {
   });
   Q.all(all).then(function () {
     deferred.resolve();
+  }).catch(function (err) {
+    if (err) {
+      deferred.reject(err);  
+    }
   });
   return deferred.promise;
 };


### PR DESCRIPTION
Had to run 'brew link libtool' to resolve error `dyld: Library not loaded:`. This failed silently and no icons generated.