### PR TITLE
added android version detection to automatically adjust output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var colors = require('colors');
 var _      = require('underscore');
 var Q      = require('q');
 var argv   = require('minimist')(process.argv.slice(2));
+var semver = require('semver');
 
 /**
  * @var {Object} settings - names of the config file and of the icon image
@@ -14,6 +15,22 @@ var settings = {};
 settings.CONFIG_FILE = argv.config || 'config.xml';
 settings.ICON_FILE = argv.icon || 'icon.png';
 settings.OLD_XCODE_PATH = argv['xcode-old'] || false;
+
+
+/**
+ * Get Android Folder based on Android Platform version
+ */
+var getAndroidFolder = function(){
+  var androidFolder = 'platforms/android/app/src/main/res/'; //as of cordova-android@7.0.0
+  if(!fs.existsSync('platforms/android/cordova/version')){
+    return androidFolder;
+  }
+  if(semver.lt(require('../../platforms/android/cordova/version').version, '7.0.0')){
+    androidFolder = 'platforms/android/res/';
+  }
+  return androidFolder;
+}
+
 
 /**
  * Check which platforms are added to the project and return their icon names and sizes
@@ -69,7 +86,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'android',
     isAdded : fs.existsSync('platforms/android'),
-    iconsPath : 'platforms/android/res/',
+    iconsPath : getAndroidFolder(),
     icons : [
       { name : 'drawable/icon.png',       size : 96 },
       { name : 'drawable-hdpi/icon.png',  size : 72 },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "imagemagick": "^0.1.3",
     "minimist": "^1.2.0",
     "q": "^1.0.1",
+    "semver": "^5.5.0",
     "underscore": "^1.6.0",
     "xml2js": "^0.4.3"
   }


### PR DESCRIPTION
as of cordova-android@7.0.0 the folder structure for the assets have been relocated. I added a function to detect the android version and adjust the destination folder.