### PR TITLE
adjust android output folder based on cordova-android version

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,12 @@ settings.OLD_XCODE_PATH = argv['xcode-old'] || false;
  */
 var getAndroidFolder = function(){
   var androidFolder = 'platforms/android/app/src/main/res/'; //as of cordova-android@7.0.0
-  if(!fs.existsSync('platforms/android/cordova/version')){
+  var versionAbsolutePath = path.resolve(process.cwd(), 'platforms/android/cordova/version');
+
+  if(!fs.existsSync(versionAbsolutePath)){
     return androidFolder;
   }
-  if(semver.lt(require('../../platforms/android/cordova/version').version, '7.0.0')){
+  if(semver.lt(require(versionAbsolutePath).version, '7.0.0')){
     androidFolder = 'platforms/android/res/';
   }
   return androidFolder;


### PR DESCRIPTION
as of cordova-android@7.0.0 the folder structure for the assets have been relocated. I added a function to detect the android version and adjust the destination folder. I updated it to use an absolute folder path to address issue 115