### PR TITLE
add param iconspath

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ If you run a old version of Cordova for iOS / Mac and you need your files in `/R
 
      $ cordova-icon --xcode-old
 
-In some case you must specify the destiny path to export to icons:
-
-     $ cordova-icon --iconspath=platforms/res/
-
 If you want specify what platforms with be generate icons:
 
-    $ cordova-icon --platfoms=android
-    $ cordova-icon --platfoms=ios:android
+    $ cordova-icon --platfoms=ios:windows
+
+In some case you must specify the destiny path to export to icons:
+
+     $ cordova-icon --iconspath=platforms/android/res/ --platfoms=android
 
 For good results, your file should be:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ If you run a old version of Cordova for iOS / Mac and you need your files in `/R
 
      $ cordova-icon --xcode-old
 
+In some case you must specify the destiny to export. for the icons You can specify the destiny dirpath to export the icons:
+
+     $ cordova-icon --iconspath=platforms/res/
+
 For good results, your file should be:
 
 - square

--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ If you run a old version of Cordova for iOS / Mac and you need your files in `/R
 
      $ cordova-icon --xcode-old
 
-In some case you must specify the destiny to export. for the icons You can specify the destiny dirpath to export the icons:
+In some case you must specify the destiny path to export to icons:
 
      $ cordova-icon --iconspath=platforms/res/
+
+If you want specify what platforms with be generate icons:
+
+    $ cordova-icon --platfoms=android
+    $ cordova-icon --platfoms=ios:android
 
 For good results, your file should be:
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ settings.CONFIG_FILE = argv.config || 'config.xml';
 settings.ICON_FILE = argv.icon || 'icon.png';
 settings.OLD_XCODE_PATH = argv['xcode-old'] || false;
 settings.ICONS_PATH = argv['iconspath'] || false;
+settings.PLATFORMS = (argv['platforms'] || 'ios:android:osx:windows').split(':');
 
 /**
  * Check which platforms are added to the project and return their icon names and sizes
@@ -31,134 +32,142 @@ var getPlatforms = function (projectName) {
     xcodeFolder = '/Resources/icons/';
   }
 
-  platforms.push({
-    name : 'ios',
-    // TODO: use async fs.exists
-    isAdded : fs.existsSync('platforms/ios'),
-    iconsPath : (settings.ICONS_PATH || 'platforms/ios/' + projectName + (xcodeFolder)),
-    icons : [
-      { name: 'icon-20.png',             size : 20   },
-      { name: 'icon-20@2x.png',          size : 40   },
-      { name: 'icon-20@3x.png',          size : 60   },
-      { name: 'icon-40.png',             size : 40   },
-      { name: 'icon-40@2x.png',          size : 80   },
-      { name: 'icon-50.png',             size : 50   },
-      { name: 'icon-50@2x.png',          size : 100  },
-      { name: 'icon-60@2x.png',          size : 120  },
-      { name: 'icon-60@3x.png',          size : 180  },
-      { name: 'icon-72.png',             size : 72   },
-      { name: 'icon-72@2x.png',          size : 144  },
-      { name: 'icon-76.png',             size : 76   },
-      { name: 'icon-76@2x.png',          size : 152  },
-      { name: 'icon-83.5@2x.png',        size : 167  },
-      { name: 'icon-1024.png',           size : 1024 },
-      { name: 'icon-small.png',          size : 29   },
-      { name: 'icon-small@2x.png',       size : 58   },
-      { name: 'icon-small@3x.png',       size : 87   },
-      { name: 'icon.png',                size : 57   },
-      { name: 'icon@2x.png',             size : 114  },
-      { name: 'AppIcon24x24@2x.png',     size : 48   },
-      { name: 'AppIcon27.5x27.5@2x.png', size : 55   },
-      { name: 'AppIcon29x29@2x.png',     size : 58   },
-      { name: 'AppIcon29x29@3x.png',     size : 87   },
-      { name: 'AppIcon40x40@2x.png',     size : 80   },
-      { name: 'AppIcon44x44@2x.png',     size : 88   },
-      { name: 'AppIcon86x86@2x.png',     size : 172  },
-      { name: 'AppIcon98x98@2x.png',     size : 196  }
-    ]
-  });
-  platforms.push({
-    name : 'android',
-    isAdded : fs.existsSync('platforms/android'),
-    iconsPath : (settings.ICONS_PATH || ('platforms/android/app/src/main/res/')),
-    icons : [
-      { name : 'drawable/icon.png',       size : 96 },
-      { name : 'drawable-hdpi/icon.png',  size : 72 },
-      { name : 'drawable-ldpi/icon.png',  size : 36 },
-      { name : 'drawable-mdpi/icon.png',  size : 48 },
-      { name : 'drawable-xhdpi/icon.png', size : 96 },
-      { name : 'drawable-xxhdpi/icon.png', size : 144 },
-      { name : 'drawable-xxxhdpi/icon.png', size : 192 },
-      { name : 'mipmap-hdpi/icon.png',  size : 72 },
-      { name : 'mipmap-ldpi/icon.png',  size : 36 },
-      { name : 'mipmap-mdpi/icon.png',  size : 48 },
-      { name : 'mipmap-xhdpi/icon.png', size : 96 },
-      { name : 'mipmap-xxhdpi/icon.png', size : 144 },
-      { name : 'mipmap-xxxhdpi/icon.png', size : 192 }
-    ]
-  });
-  platforms.push({
-    name : 'osx',
-    // TODO: use async fs.exists
-    isAdded : fs.existsSync('platforms/osx'),
-    iconsPath : (settings.ICONS_PATH || ('platforms/osx/' + projectName + xcodeFolder)),
-    icons : [
-      { name : 'icon-16x16.png',    size : 16  },
-      { name : 'icon-32x32.png',    size : 32  },
-      { name : 'icon-64x64.png',    size : 64  },
-      { name : 'icon-128x128.png',  size : 128 },
-      { name : 'icon-256x256.png',  size : 256 },
-      { name : 'icon-512x512.png',  size : 512 }
-    ]
-  });
-  platforms.push({
-    name : 'windows',
-    isAdded : fs.existsSync('platforms/windows'),
-    iconsPath : (settings.ICONS_PATH || ('platforms/windows/images/')),
-    icons : [
-      { name : 'StoreLogo.scale-100.png', size : 50  },
-      { name : 'StoreLogo.scale-125.png', size : 63  },
-      { name : 'StoreLogo.scale-140.png', size : 70  },
-      { name : 'StoreLogo.scale-150.png', size : 75  },
-      { name : 'StoreLogo.scale-180.png', size : 90  },
-      { name : 'StoreLogo.scale-200.png', size : 100 },
-      { name : 'StoreLogo.scale-240.png', size : 120 },
-      { name : 'StoreLogo.scale-400.png', size : 200 },
+  if (settings.PLATFORMS.indexOf('ios')!==-1) {
+    platforms.push({
+      name : 'ios',
+      // TODO: use async fs.exists
+      isAdded : fs.existsSync('platforms/ios'),
+      iconsPath : (settings.ICONS_PATH || 'platforms/ios/' + projectName + (xcodeFolder)),
+      icons : [
+        { name: 'icon-20.png',             size : 20   },
+        { name: 'icon-20@2x.png',          size : 40   },
+        { name: 'icon-20@3x.png',          size : 60   },
+        { name: 'icon-40.png',             size : 40   },
+        { name: 'icon-40@2x.png',          size : 80   },
+        { name: 'icon-50.png',             size : 50   },
+        { name: 'icon-50@2x.png',          size : 100  },
+        { name: 'icon-60@2x.png',          size : 120  },
+        { name: 'icon-60@3x.png',          size : 180  },
+        { name: 'icon-72.png',             size : 72   },
+        { name: 'icon-72@2x.png',          size : 144  },
+        { name: 'icon-76.png',             size : 76   },
+        { name: 'icon-76@2x.png',          size : 152  },
+        { name: 'icon-83.5@2x.png',        size : 167  },
+        { name: 'icon-1024.png',           size : 1024 },
+        { name: 'icon-small.png',          size : 29   },
+        { name: 'icon-small@2x.png',       size : 58   },
+        { name: 'icon-small@3x.png',       size : 87   },
+        { name: 'icon.png',                size : 57   },
+        { name: 'icon@2x.png',             size : 114  },
+        { name: 'AppIcon24x24@2x.png',     size : 48   },
+        { name: 'AppIcon27.5x27.5@2x.png', size : 55   },
+        { name: 'AppIcon29x29@2x.png',     size : 58   },
+        { name: 'AppIcon29x29@3x.png',     size : 87   },
+        { name: 'AppIcon40x40@2x.png',     size : 80   },
+        { name: 'AppIcon44x44@2x.png',     size : 88   },
+        { name: 'AppIcon86x86@2x.png',     size : 172  },
+        { name: 'AppIcon98x98@2x.png',     size : 196  }
+      ]
+    });
+  }
+  if (settings.PLATFORMS.indexOf('android')!==-1) {
+    platforms.push({
+      name : 'android',
+      isAdded : fs.existsSync('platforms/android'),
+      iconsPath : (settings.ICONS_PATH || ('platforms/android/app/src/main/res/')),
+      icons : [
+        { name : 'drawable/icon.png',       size : 96 },
+        { name : 'drawable-hdpi/icon.png',  size : 72 },
+        { name : 'drawable-ldpi/icon.png',  size : 36 },
+        { name : 'drawable-mdpi/icon.png',  size : 48 },
+        { name : 'drawable-xhdpi/icon.png', size : 96 },
+        { name : 'drawable-xxhdpi/icon.png', size : 144 },
+        { name : 'drawable-xxxhdpi/icon.png', size : 192 },
+        { name : 'mipmap-hdpi/icon.png',  size : 72 },
+        { name : 'mipmap-ldpi/icon.png',  size : 36 },
+        { name : 'mipmap-mdpi/icon.png',  size : 48 },
+        { name : 'mipmap-xhdpi/icon.png', size : 96 },
+        { name : 'mipmap-xxhdpi/icon.png', size : 144 },
+        { name : 'mipmap-xxxhdpi/icon.png', size : 192 }
+      ]
+    });
+  }
+  if (settings.PLATFORMS.indexOf('osx')!==-1) {
+    platforms.push({
+      name : 'osx',
+      // TODO: use async fs.exists
+      isAdded : fs.existsSync('platforms/osx'),
+      iconsPath : (settings.ICONS_PATH || ('platforms/osx/' + projectName + xcodeFolder)),
+      icons : [
+        { name : 'icon-16x16.png',    size : 16  },
+        { name : 'icon-32x32.png',    size : 32  },
+        { name : 'icon-64x64.png',    size : 64  },
+        { name : 'icon-128x128.png',  size : 128 },
+        { name : 'icon-256x256.png',  size : 256 },
+        { name : 'icon-512x512.png',  size : 512 }
+      ]
+    });
+  }
+  if (settings.PLATFORMS.indexOf('windows')!==-1) {
+    platforms.push({
+      name : 'windows',
+      isAdded : fs.existsSync('platforms/windows'),
+      iconsPath : (settings.ICONS_PATH || ('platforms/windows/images/')),
+      icons : [
+        { name : 'StoreLogo.scale-100.png', size : 50  },
+        { name : 'StoreLogo.scale-125.png', size : 63  },
+        { name : 'StoreLogo.scale-140.png', size : 70  },
+        { name : 'StoreLogo.scale-150.png', size : 75  },
+        { name : 'StoreLogo.scale-180.png', size : 90  },
+        { name : 'StoreLogo.scale-200.png', size : 100 },
+        { name : 'StoreLogo.scale-240.png', size : 120 },
+        { name : 'StoreLogo.scale-400.png', size : 200 },
 
-      { name : 'Square44x44Logo.scale-100.png', size : 44  },
-      { name : 'Square44x44Logo.scale-125.png', size : 55  },
-      { name : 'Square44x44Logo.scale-140.png', size : 62  },
-      { name : 'Square44x44Logo.scale-150.png', size : 66  },
-      { name : 'Square44x44Logo.scale-200.png', size : 88  },
-      { name : 'Square44x44Logo.scale-240.png', size : 106  },
-      { name : 'Square44x44Logo.scale-400.png', size : 176 },
+        { name : 'Square44x44Logo.scale-100.png', size : 44  },
+        { name : 'Square44x44Logo.scale-125.png', size : 55  },
+        { name : 'Square44x44Logo.scale-140.png', size : 62  },
+        { name : 'Square44x44Logo.scale-150.png', size : 66  },
+        { name : 'Square44x44Logo.scale-200.png', size : 88  },
+        { name : 'Square44x44Logo.scale-240.png', size : 106  },
+        { name : 'Square44x44Logo.scale-400.png', size : 176 },
 
-      { name : 'Square71x71Logo.scale-100.png', size : 71  },
-      { name : 'Square71x71Logo.scale-125.png', size : 89  },
-      { name : 'Square71x71Logo.scale-140.png', size : 99 },
-      { name : 'Square71x71Logo.scale-150.png', size : 107 },
-      { name : 'Square71x71Logo.scale-200.png', size : 142 },
-      { name : 'Square71x71Logo.scale-240.png', size : 170 },
-      { name : 'Square71x71Logo.scale-400.png', size : 284 },
+        { name : 'Square71x71Logo.scale-100.png', size : 71  },
+        { name : 'Square71x71Logo.scale-125.png', size : 89  },
+        { name : 'Square71x71Logo.scale-140.png', size : 99 },
+        { name : 'Square71x71Logo.scale-150.png', size : 107 },
+        { name : 'Square71x71Logo.scale-200.png', size : 142 },
+        { name : 'Square71x71Logo.scale-240.png', size : 170 },
+        { name : 'Square71x71Logo.scale-400.png', size : 284 },
 
-      { name : 'Square150x150Logo.scale-100.png', size : 150 },
-      { name : 'Square150x150Logo.scale-125.png', size : 188 },
-      { name : 'Square150x150Logo.scale-140.png', size : 210 },
-      { name : 'Square150x150Logo.scale-150.png', size : 225 },
-      { name : 'Square150x150Logo.scale-200.png', size : 300 },
-      { name : 'Square150x150Logo.scale-240.png', size : 360 },
-      { name : 'Square150x150Logo.scale-400.png', size : 600 },
+        { name : 'Square150x150Logo.scale-100.png', size : 150 },
+        { name : 'Square150x150Logo.scale-125.png', size : 188 },
+        { name : 'Square150x150Logo.scale-140.png', size : 210 },
+        { name : 'Square150x150Logo.scale-150.png', size : 225 },
+        { name : 'Square150x150Logo.scale-200.png', size : 300 },
+        { name : 'Square150x150Logo.scale-240.png', size : 360 },
+        { name : 'Square150x150Logo.scale-400.png', size : 600 },
 
-      { name : 'Square310x310Logo.scale-100.png', size : 310  },
-      { name : 'Square310x310Logo.scale-125.png', size : 388  },
-      { name : 'Square310x310Logo.scale-140.png', size : 434  },
-      { name : 'Square310x310Logo.scale-150.png', size : 465  },
-      { name : 'Square310x310Logo.scale-180.png', size : 558  },
-      { name : 'Square310x310Logo.scale-200.png', size : 620  },
-      { name : 'Square310x310Logo.scale-400.png', size : 1240 },
+        { name : 'Square310x310Logo.scale-100.png', size : 310  },
+        { name : 'Square310x310Logo.scale-125.png', size : 388  },
+        { name : 'Square310x310Logo.scale-140.png', size : 434  },
+        { name : 'Square310x310Logo.scale-150.png', size : 465  },
+        { name : 'Square310x310Logo.scale-180.png', size : 558  },
+        { name : 'Square310x310Logo.scale-200.png', size : 620  },
+        { name : 'Square310x310Logo.scale-400.png', size : 1240 },
 
-      { name : 'Wide310x150Logo.scale-80.png', size : 248, height : 120  },
-      { name : 'Wide310x150Logo.scale-100.png', size : 310, height : 150  },
-      { name : 'Wide310x150Logo.scale-125.png', size : 388, height : 188  },
-      { name : 'Wide310x150Logo.scale-140.png', size : 434, height : 210  },
-      { name : 'Wide310x150Logo.scale-150.png', size : 465, height : 225  },
-      { name : 'Wide310x150Logo.scale-180.png', size : 558, height : 270  },
-      { name : 'Wide310x150Logo.scale-200.png', size : 620, height : 300  },
-      { name : 'Wide310x150Logo.scale-240.png', size : 744, height : 360  },
-      { name : 'Wide310x150Logo.scale-400.png', size : 1240, height : 600 }
-    ]
-  });
-  // TODO: add missing platforms
+        { name : 'Wide310x150Logo.scale-80.png', size : 248, height : 120  },
+        { name : 'Wide310x150Logo.scale-100.png', size : 310, height : 150  },
+        { name : 'Wide310x150Logo.scale-125.png', size : 388, height : 188  },
+        { name : 'Wide310x150Logo.scale-140.png', size : 434, height : 210  },
+        { name : 'Wide310x150Logo.scale-150.png', size : 465, height : 225  },
+        { name : 'Wide310x150Logo.scale-180.png', size : 558, height : 270  },
+        { name : 'Wide310x150Logo.scale-200.png', size : 620, height : 300  },
+        { name : 'Wide310x150Logo.scale-240.png', size : 744, height : 360  },
+        { name : 'Wide310x150Logo.scale-400.png', size : 1240, height : 600 }
+      ]
+    });
+  }
+    // TODO: add missing platforms
   deferred.resolve(platforms);
   return deferred.promise;
 };

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var settings = {};
 settings.CONFIG_FILE = argv.config || 'config.xml';
 settings.ICON_FILE = argv.icon || 'icon.png';
 settings.OLD_XCODE_PATH = argv['xcode-old'] || false;
+settings.ICONS_PATH = argv['iconspath'] || false;
 
 /**
  * Check which platforms are added to the project and return their icon names and sizes
@@ -34,7 +35,7 @@ var getPlatforms = function (projectName) {
     name : 'ios',
     // TODO: use async fs.exists
     isAdded : fs.existsSync('platforms/ios'),
-    iconsPath : 'platforms/ios/' + projectName + xcodeFolder,
+    iconsPath : (settings.ICONS_PATH || 'platforms/ios/' + projectName + (xcodeFolder)),
     icons : [
       { name: 'icon-20.png',             size : 20   },
       { name: 'icon-20@2x.png',          size : 40   },
@@ -69,7 +70,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'android',
     isAdded : fs.existsSync('platforms/android'),
-    iconsPath : 'platforms/android/app/src/main/res/',
+    iconsPath : (settings.ICONS_PATH || ('platforms/android/app/src/main/res/')),
     icons : [
       { name : 'drawable/icon.png',       size : 96 },
       { name : 'drawable-hdpi/icon.png',  size : 72 },
@@ -90,7 +91,7 @@ var getPlatforms = function (projectName) {
     name : 'osx',
     // TODO: use async fs.exists
     isAdded : fs.existsSync('platforms/osx'),
-    iconsPath : 'platforms/osx/' + projectName + xcodeFolder,
+    iconsPath : (settings.ICONS_PATH || ('platforms/osx/' + projectName + xcodeFolder)),
     icons : [
       { name : 'icon-16x16.png',    size : 16  },
       { name : 'icon-32x32.png',    size : 32  },
@@ -103,7 +104,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'windows',
     isAdded : fs.existsSync('platforms/windows'),
-    iconsPath : 'platforms/windows/images/',
+    iconsPath : (settings.ICONS_PATH || ('platforms/windows/images/')),
     icons : [
       { name : 'StoreLogo.scale-100.png', size : 50  },
       { name : 'StoreLogo.scale-125.png', size : 63  },


### PR DESCRIPTION
I'd added a new param to specify dirpath to export the icons to fix issue [https://github.com/AlexDisler/cordova-icon/issues/118](118)

```sh
$ cordova-icon --iconspath=platforms/android/res/ --platforms=android
```

I'd added a new param to specify whats platforms to generate to fix issue [https://github.com/AlexDisler/cordova-icon/issues/26](26)

```sh
$ cordova-icon --platforms=windows:ios
```
